### PR TITLE
Fix typo in GWCS notebook

### DIFF
--- a/gwcs/GWCS.ipynb
+++ b/gwcs/GWCS.ipynb
@@ -179,7 +179,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "ra, dec = w.pixel_to_world_values(100, 200)\n",
     "\n",
     "print(f\"World values (numerical): {ra, dec}\")\n",
@@ -419,7 +418,7 @@
    "outputs": [],
    "source": [
     "s50 = jnrs.slits[50]\n",
-    "w50 = s50.meta.wcs"
+    "w0 = s50.meta.wcs"
    ]
   },
   {
@@ -609,14 +608,6 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e321c579-7770-4a71-b316-75ccce9d6448",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "435845f0-e178-43ed-9d1b-48ef02fabfee",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Fixed a small typo that was preventing the GWCS notebook from running to completion.

CC: @nden